### PR TITLE
Promise to callback

### DIFF
--- a/package.json
+++ b/package.json
@@ -117,9 +117,9 @@
     }
   },
   "dependencies": {
+    "promise-to-callback": "^1.0.0"
   },
   "devDependencies": {
-    "ethjs-format": "0.1.8",
     "babel-cli": "6.18.0",
     "babel-core": "6.18.2",
     "babel-eslint": "7.1.0",
@@ -146,27 +146,28 @@
     "babel-plugin-transform-es3-property-literals": "6.5.0",
     "babel-plugin-transform-object-rest-spread": "6.19.0",
     "babel-register": "6.18.0",
-    "check-es3-syntax-cli": "0.1.3",
-    "webpack": "2.1.0-beta.15",
-    "json-loader": "0.5.4",
-    "rimraf": "2.3.4",
-    "cross-env": "1.0.7",
     "bignumber.js": "3.0.1",
     "chai": "3.5.0",
+    "check-es3-syntax-cli": "0.1.3",
     "coveralls": "2.11.9",
+    "cross-env": "1.0.7",
     "eslint": "2.10.1",
     "eslint-config-airbnb": "9.0.1",
     "eslint-import-resolver-webpack": "0.2.4",
     "eslint-plugin-import": "1.8.0",
     "eslint-plugin-jsx-a11y": "1.2.0",
     "eslint-plugin-react": "5.1.1",
-    "ethjs-provider-http": "*",
     "ethereumjs-testrpc": "3.0.2",
     "ethjs-abi": "0.0.1",
+    "ethjs-format": "0.1.8",
+    "ethjs-provider-http": "*",
     "istanbul": "0.4.5",
+    "json-loader": "0.5.4",
     "lint-staged": "1.0.1",
-    "mocha": "3.2.0",
-    "pre-commit": "1.1.3"
+    "mocha": "^5.1.1",
+    "pre-commit": "1.1.3",
+    "rimraf": "2.3.4",
+    "webpack": "2.1.0-beta.15"
   },
   "lint-staged": {
     "lint:eslint": "*.js"

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,5 @@
+const promiseToCallback = require('promise-to-callback');
+
 module.exports = EthRPC;
 
 /**
@@ -59,17 +61,11 @@ EthRPC.prototype.sendAsync = function sendAsync(payload, callback) {
 
   if (callback) {
     // connect promise resolve handlers to callback
-    promise.then((result) => {
-      callback(null, result);
-    }).catch((err) => {
-      callback(err);
-    });
-  } else {
-    // only return promise if no callback specified
-    return promise;
+    return promiseToCallback(promise)(callback);
   }
 
-  return undefined;
+  // only return promise if no callback specified
+  return promise;
 };
 
 /**

--- a/src/tests/test.index.js
+++ b/src/tests/test.index.js
@@ -98,16 +98,44 @@ describe('ethjs-rpc', () => {
         done();
       });
     });
+  });
+
+  describe('sendAsync - error handling', () => {
+    // this test relies on disabling mocha's default handling of "uncaughtException"
+    // see https://github.com/mochajs/mocha/issues/2452
+
+    let uncaughtExceptionListeners;
+
+    before(() => {
+      // Stop Mocha from handling uncaughtExceptions.
+      uncaughtExceptionListeners = process.listeners('uncaughtException');
+      process.removeAllListeners('uncaughtException');
+    });
+
+    after(() => {
+      // Resume normal Mocha handling of uncaughtExceptions.
+      uncaughtExceptionListeners.forEach((listener) => {
+        process.on('uncaughtException', listener);
+      });
+    });
 
     it('should call the callback only once', (done) => {
       const eth = new EthRPC(provider);
+      const errorMessage = 'boom!';
       let callbackCalled = 0;
+      let uncaughtException;
+
+      process.prependOnceListener('uncaughtException', (err) => {
+        uncaughtException = err;
+      });
       eth.sendAsync({ method: 'eth_accounts' }, () => {
         callbackCalled++;
-        throw new Error('boom!');
+        throw new Error(errorMessage);
       });
+
       setTimeout(() => {
         assert.equal(callbackCalled, 1, 'callback called only once.');
+        assert.equal(uncaughtException.message, errorMessage, 'saw expected uncaughtException');
         done();
       }, 200);
     });

--- a/src/tests/test.index.js
+++ b/src/tests/test.index.js
@@ -98,5 +98,18 @@ describe('ethjs-rpc', () => {
         done();
       });
     });
+
+    it('should call the callback only once', (done) => {
+      const eth = new EthRPC(provider);
+      let callbackCalled = 0;
+      eth.sendAsync({ method: 'eth_accounts' }, () => {
+        callbackCalled++;
+        throw new Error('boom!');
+      });
+      setTimeout(() => {
+        assert.equal(callbackCalled, 1, 'callback called only once.');
+        done();
+      }, 200);
+    });
   });
 });


### PR DESCRIPTION
Fixes #5 
only added  `"promise-to-callback": "^1.0.0"` to deps but npm automatically sorted the devDeps